### PR TITLE
Create gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,17 @@
+# Project-wide Gradle settings.
+
+# IDE (e.g. Android Studio) users:
+# Gradle settings configured through the IDE *will override*
+# any settings specified in this file.
+
+# For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+# org.gradle.jvmargs=-Xms1024m -Xmx2048m
+
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. More details, visit
+# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+# org.gradle.parallel=true


### PR DESCRIPTION
To avoid confusion for newbies who panic when they notice the file is missing.
Provides option to configure gradle RAM usage settings and enable/disable parallel mode.
Both options should strictly be configured according to developers hardware capabilities.